### PR TITLE
LLW-89 Guest Payment Success Page

### DIFF
--- a/core/templates/partials/payment_success_content.html
+++ b/core/templates/partials/payment_success_content.html
@@ -1,0 +1,38 @@
+
+{% block content %}   
+{% load static %}
+
+<style>
+.serif-text {
+    font-family: serif;
+}
+</style>
+
+    <main class="d-flex justify-content-center align-items-center" style="min-height: 70vh;">
+
+        <!-- Outside container -->
+         <div style="max-width: 900px; width: 100%; text-align: center;">
+
+            <!-- Container for logo on left and text on right -> stacked on mobile -->
+                    <div class="d-flex flex-column flex-md-row justify-content-center align-items-center mb-4">
+
+                        <!-- Container for Logo -->
+                        <div class=" mb-3 mb-md-0 me-md-4">
+                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                        </div>
+
+                        <!-- Container for Text-->
+                        <div class="serif-text text-center text-md-start">
+                            <h1 class="mb-2">Payment Confirmed!</h1>  
+
+                            <!-- Container for Close Button -->
+                            <div class="d-flex justify-content-center">
+                                <a href="/" class=" serif-text btn btn-custom px-4 py-2 rounded-pill mt-4">Close</a>
+                            </div>              
+
+                        </div>
+                    </div>
+
+         </div> <!-- close outer container-->       
+    </main> <!-- close main -->
+{% endblock %}

--- a/core/templates/payment.html
+++ b/core/templates/payment.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block title %}Guest Payment{% endblock %}
+{% block title %}Payment{% endblock %}
 
 {% block content %}
 {% include 'partials/payment_content.html' %}

--- a/core/templates/payment_success.html
+++ b/core/templates/payment_success.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block title %}Payment Success{% endblock %}
+
+{% block content %}
+{% include 'partials/payment_success_content.html' %}
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path("schedule/", views.schedule, name="schedule"),
     path("privacy/", views.privacy, name="privacy"),
     path("appointment_confirmation/", views.appointment_confirmation, name="appointment_confirmation"),
+    path("payment/success/", views.payment_success, name="payment_success"),
 
     # users pages
     path("users/", include("users.urls")),

--- a/core/views.py
+++ b/core/views.py
@@ -37,6 +37,7 @@ def payment(r): return render(r, "payment.html")
 def schedule(r): return render(r, "schedule.html")
 def privacy(r): return render(r, "privacy.html")
 def appointment_confirmation(r): return render (r, "appointment_confirmation.html")
+def payment_success(r): return render (r, "payment_success.html")
 
 def login(r): 
     role = r.GET.get("role", "guest")


### PR DESCRIPTION
Made Guest Payment Success page. 

Can be found under /payment/success/

Things to note:
- We decided not to have the Order Summary on the page as Stripe does that for us
- We also may run into issues getting the Amount from the Invoice table because the Invoice ID is needed, but if the user is redirected to Stripe we may lose the ID they entered to retrieve it




<img width="1592" height="873" alt="Screenshot 2026-02-15 194747" src="https://github.com/user-attachments/assets/edc0dab6-0832-46bc-83ef-d7de3bc27ff5" />
