### PR TITLE
LLW #249 Load clients under the Client page under admin and create UI

### DIFF
--- a/Lydias_Law_Site/settings.py
+++ b/Lydias_Law_Site/settings.py
@@ -121,6 +121,7 @@ ACCOUNT_SIGNUP_REDIRECT_URL = "client/dashboard"
 ACCOUNT_LOGOUT_REDIRECT_URL = "home"
 ACCOUNT_LOGIN_REDIRECT_URL = '/client/dashboard/'
 ACCOUNT_ADAPTER = "users.adapter.MyAccountAdapter"
+SOCIALACCOUNT_ADAPTER = "users.adapter.CustomSocialAccountAdapter"
 
 # Select Custom User
 AUTH_USER_MODEL = "users.User"
@@ -159,9 +160,7 @@ SOCIALACCOUNT_LOGIN_ON_GET = True
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_AUTHENTICATION_METHOD = 'email'
-ACCOUNT_FORMS = {
-    "signup": "users.forms.CustomSignupForm"
-}
+
 
 # Email Verification Email
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"

--- a/core/templates/admin/clients.html
+++ b/core/templates/admin/clients.html
@@ -1,16 +1,165 @@
 {% extends "admin/base_admin.html" %}
 
 {% block title %}Clients – Admin{% endblock %}
+{% load phone_filter %}
+
+{% block extra_css %}
+<style>
+  .client-card {
+    background-color: #C3D5D6;
+    border-radius: .5rem;
+    padding: 1rem 1.25rem;
+    margin-bottom: .75rem;
+  }
+  .client-label {
+    font-size: .7rem;
+    color: #555;
+    text-transform: uppercase;
+  }
+  .client-value {
+    font-size: .95rem;
+    color: #1a1a1a;
+  }
+</style>
+{% endblock %}
 
 {% block content %}
-<div class="row">
-  <div class="col-12">
-    <h1 class="h3 mb-4">Clients</h1>
-    <div class="card">
-      <div class="card-body">
-        <p class="text-muted">Client management coming soon...</p>
-      </div>
+<!-- Header -->
+<div class="p-3 mb-3 rounded" style="background-color: #e8f2f0;">
+  <h1 class="text-center fw-normal" style="font-family: serif; padding: 1rem 0 0 1rem; font-size: 3rem;">
+    Clients
+  </h1>
+</div>
+
+<div class="container-fluid px-5 py-3">
+
+  <!-- Filters + Search -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <form method="get" class="row g-3 align-items-end">
+        <!-- Reset page to 1 on new search/filter -->
+        <input type="hidden" name="page" value="1">
+
+        <!-- Search -->
+        <div class="col-md-4">
+          <label class="form-label">Search</label>
+          <input type="text" name="search" class="form-control"
+                 placeholder="Name, email, or phone"
+                 value="{{ search_query }}">
+        </div>
+
+        <!-- Balance Filter -->
+        <div class="col-md-3">
+          <label class="form-label">Balance</label>
+          <select name="balance" class="form-select">
+            <option value="">All</option>
+            <option value="has_balance" {% if balance_filter == "has_balance" %}selected{% endif %}>
+              Has Balance
+            </option>
+            <option value="no_balance" {% if balance_filter == "no_balance" %}selected{% endif %}>
+              No Balance
+            </option>
+          </select>
+        </div>
+
+        <!-- Sort -->
+        <div class="col-md-3">
+          <label class="form-label">Sort</label>
+          <select name="sort" class="form-select">
+            <option value="asc" {% if sort == "asc" %}selected{% endif %}>A–Z</option>
+            <option value="desc" {% if sort == "desc" %}selected{% endif %}>Z–A</option>
+          </select>
+        </div>
+
+        <!-- Buttons -->
+        <div class="col-md-2 d-flex gap-2">
+          <button type="submit" class="btn text-white w-100"
+                  style="background-color: #2d7a73;">
+            Apply
+          </button>
+          <a href="?" class="btn btn-outline-secondary w-100">Clear</a>
+        </div>
+
+      </form>
     </div>
   </div>
+
+  <!-- Client Cards -->
+  {% for user in page_obj %}
+    <div class="client-card d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2 gap-md-4 p-3">
+
+      <!-- Name -->
+      <div class="client-col" style="min-width: 200px; flex: 1;">
+        <div class="client-label">Name</div>
+        <div class="client-value">{{ user.first_name }} {{ user.last_name }}</div>
+      </div>
+
+      <!-- Email -->
+      <div class="client-col" style="min-width: 250px; flex: 1.5;">
+        <div class="client-label">Email</div>
+        <div class="client-value">{{ user.email }}</div>
+      </div>
+
+      <!-- Phone -->
+      <div class="client-col" style="min-width: 150px; flex: 1;">
+        <div class="client-label">Phone</div>
+        <div class="client-value">{{ user.phone_number|format_phone|default:"--" }}</div>
+      </div>
+
+      <!-- Balance -->
+      <div class="client-col" style="min-width: 100px; flex: 0.7;">
+        <div class="client-label">Balance</div>
+        <div class="client-value">${{ user.retainer_balance }}</div>
+      </div>
+    </div>
+  {% empty %}
+    <div class="text-center text-muted py-5">
+      No clients found.
+    </div>
+  {% endfor %}
+
+  <!-- Pagination -->
+  {% if page_obj.has_other_pages %}
+    <nav class="mt-3">
+      <ul class="pagination justify-content-center">
+
+        {% if page_obj.has_previous %}
+          <li class="page-item">
+            <a class="page-link"
+               href="?page={{ page_obj.previous_page_number }}
+               {% if search_query %}&search={{ search_query }}{% endif %}
+               {% if balance_filter %}&balance={{ balance_filter }}{% endif %}
+               {% if sort %}&sort={{ sort }}{% endif %}">
+               Previous
+            </a>
+          </li>
+        {% endif %}
+
+        {% for num in page_obj.paginator.page_range %}
+          <li class="page-item {% if page_obj.number == num %}active{% endif %}">
+            <a class="page-link"
+               href="?page={{ num }}
+               {% if search_query %}&search={{ search_query }}{% endif %}
+               {% if balance_filter %}&balance={{ balance_filter }}{% endif %}
+               {% if sort %}&sort={{ sort }}{% endif %}">
+               {{ num }}
+            </a>
+          </li>
+        {% endfor %}
+
+        {% if page_obj.has_next %}
+          <li class="page-item">
+            <a class="page-link"
+                href="?page={{ page_obj.next_page_number }}
+               {% if search_query %}&search={{ search_query }}{% endif %}
+               {% if balance_filter %}&balance={{ balance_filter }}{% endif %}
+               {% if sort %}&sort={{ sort }}{% endif %}">
+               Next
+            </a>
+          </li>
+        {% endif %}
+      </ul>
+    </nav>
+  {% endif %}
 </div>
 {% endblock %}

--- a/core/templates/partials/contact_content.html
+++ b/core/templates/partials/contact_content.html
@@ -1,4 +1,6 @@
 {% load static %}
+{% load phone_filter %}
+
 <style>
     .contact-header-card {
         background-color: #e8f2f0;
@@ -265,7 +267,7 @@
     <div class="contact-card">
         <img src="{% static 'images/telephone.png'%}" alt="Telephone icon" style="width: 85px; height: 85px; padding: 1rem">
         <h5>Phone Number</h5>
-        <p>{{lydia.phone_number}}</p>
+        <p>{{lydia.phone_number | format_phone}}</p>
     </div>
     <div class="contact-card">
         <img src="{% static 'images/email.png'%}" alt="Email icon" style="width: 85px; height: 85px; padding: 1rem">

--- a/core/templatetags/phone_filter.py
+++ b/core/templatetags/phone_filter.py
@@ -1,0 +1,16 @@
+from django import template
+import re
+
+register = template.Library()
+
+@register.filter
+def format_phone(value):
+    if not value:
+        return "--"
+
+    digits = re.sub(r"\D", "", str(value))
+
+    if len(digits) == 10:
+        return f"({digits[:3]}) {digits[3:6]} - {digits[6:]}"
+    
+    return value

--- a/core/tests.py
+++ b/core/tests.py
@@ -168,3 +168,124 @@ class AdminAppointmentActionsTests(TestCase):
         appt.refresh_from_db()
         self.assertEqual(appt.status, Appointments.Status.CANCELLED)
         self.assertIn("That status change isn’t allowed.", self._messages(resp))
+
+#Test cases for the admin_clients view
+class AdminClientsViewTest(TestCase):    
+    def setUp(self):
+        # Create admin for login 
+        self.admin = User.objects.create_user(
+            email='admin@example.com',
+            password='adminpass',  # create_user hashes this automatically
+            first_name='Admin',
+            last_name='User',
+            role=User.Role.ADMIN,
+            is_active=True  # Make sure user is active
+        )
+        
+        # Create test clients
+        self.client_with_balance = User.objects.create_user(
+            email='client1@example.com',
+            password='password123',
+            first_name='John',
+            last_name='Doe',
+            phone_number='123-456-7890',
+            role=User.Role.CLIENT,
+            retainer_balance=100,
+            is_active=True
+        )
+        
+        self.client_no_balance = User.objects.create_user(
+            email='client2@example.com',
+            password='password123',
+            first_name='Jane',
+            last_name='Smith',
+            phone_number='987-654-3210',
+            role=User.Role.CLIENT,
+            retainer_balance=0,
+            is_active=True
+        )
+        
+        # Create non-client users that should NOT appear
+        self.guest = User.objects.create_user(
+            email='guest@example.com',
+            password='password123',
+            first_name='Guest',
+            last_name='User',
+            role=User.Role.GUEST,
+            is_active=True
+        )
+        
+    #Test that only CLIENT role users appear
+    def test_only_clients_shown(self):
+        # Login first
+        login_successful = self.client.login(email='admin@example.com', password='adminpass')
+        self.assertTrue(login_successful, "Admin login failed!")
+        
+        # Make the request
+        response = self.client.get(reverse('admin_clients'))
+        
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        
+        # Should only show 2 clients (John and Jane)
+        self.assertEqual(len(response.context['page_obj']), 2)
+        
+        # Verify all returned users have CLIENT role
+        for user in response.context['page_obj']:
+            self.assertEqual(user.role, User.Role.CLIENT)
+            
+        # Verify guest is NOT in the results
+        user_emails = [user.email for user in response.context['page_obj']]
+        self.assertNotIn('guest@example.com', user_emails)
+
+    #Test search functionality      
+    def test_search_works(self):
+        self.client.login(email='admin@example.com', password='adminpass')
+        
+        # Search by first name
+        response = self.client.get(reverse('admin_clients'), {'search': 'John'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(len(response.context['page_obj']), 1)
+        self.assertEqual(response.context['page_obj'][0].email, 'client1@example.com')
+        
+        # Search by email
+        response = self.client.get(reverse('admin_clients'), {'search': 'client2'})
+        self.assertEqual(len(response.context['page_obj']), 1)
+        self.assertEqual(response.context['page_obj'][0].email, 'client2@example.com')
+        
+        # Search by phone
+        response = self.client.get(reverse('admin_clients'), {'search': '123-456'})
+        self.assertEqual(len(response.context['page_obj']), 1)
+        self.assertEqual(response.context['page_obj'][0].email, 'client1@example.com')
+        
+    #Test balance filter functionality
+    def test_balance_filter_works(self):
+        self.client.login(email='admin@example.com', password='adminpass')
+        
+        # Filter has balance
+        response = self.client.get(reverse('admin_clients'), {'balance': 'has_balance'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(len(response.context['page_obj']), 1)
+        self.assertEqual(response.context['page_obj'][0].retainer_balance, 100)
+        
+        # Filter no balance
+        response = self.client.get(reverse('admin_clients'), {'balance': 'no_balance'})
+        self.assertEqual(len(response.context['page_obj']), 1)
+        self.assertEqual(response.context['page_obj'][0].retainer_balance, 0)
+        
+    #Test search + balance filter together
+    def test_combined_filters(self):
+        self.client.login(email='admin@example.com', password='adminpass')
+        
+        response = self.client.get(reverse('admin_clients'), {
+            'search': 'John',
+            'balance': 'has_balance'
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(len(response.context['page_obj']), 1)
+        self.assertEqual(response.context['page_obj'][0].first_name, 'John')
+        self.assertEqual(response.context['page_obj'][0].retainer_balance, 100)

--- a/core/views.py
+++ b/core/views.py
@@ -19,6 +19,9 @@ from finances.models import Invoice
 from appointments.models import Appointments, Invitee
 from users.views import is_admin_user
 from django.utils import timezone
+from users.models import User
+from django.db.models import Q
+import re
 
 
 ''' Are these needed anymore if site content is covering them?
@@ -57,8 +60,51 @@ def login(r):
 #def admin_dashboard(r): return render(r, "admin/dashboard.html")
 # @login_required
 def admin_schedule(r): return render(r, "admin/schedule.html")
-# @login_required
-def admin_clients(r): return render(r, "admin/clients.html")
+
+@login_required
+def admin_clients(request):
+    users = User.objects.filter(role__in=[User.Role.CLIENT])
+
+    # Search
+    search_query = request.GET.get('search', '').strip()
+    if search_query:
+        words = search_query.split()  # split multi-word search
+        search_filter = Q()
+        for word in words:
+            search_filter |= (
+                Q(first_name__icontains=word) |
+                Q(last_name__icontains=word) |
+                Q(email__icontains=word) |
+                Q(phone_number__icontains=word)
+            )
+        users = users.filter(search_filter)
+
+    # Balance filter
+    balance_filter = request.GET.get('balance')
+    if balance_filter == 'has_balance':
+        users = users.filter(retainer_balance__gt=0)
+    elif balance_filter == 'no_balance':
+        users = users.filter(retainer_balance=0)
+
+    # Sorting
+    sort = request.GET.get('sort', 'asc')
+    if sort == 'asc':
+        users = users.order_by('first_name')
+    elif sort == 'desc':
+        users = users.order_by('-first_name')
+
+    # Pagination
+    paginator = Paginator(users, 10)  # 10 users per page
+    page_number = request.GET.get('page', 1)  # default to first page
+    page_obj = paginator.get_page(page_number)
+
+    return render(request, 'admin/clients.html', {
+        'page_obj': page_obj,
+        'search_query': search_query,
+        'balance_filter': balance_filter,
+        'sort': sort,
+    })
+
 # @login_required
 def admin_editor(request):
     """
@@ -286,7 +332,7 @@ def client_practice_areas(r):
 #@login_required
 def client_schedule(r): return render(r, "client/schedule.html")
 
-#@login_required
+@login_required
 def client_invoices(r): 
     user = r.user
 

--- a/users/adapter.py
+++ b/users/adapter.py
@@ -1,4 +1,5 @@
 from allauth.account.adapter import DefaultAccountAdapter
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.shortcuts import redirect
 
 class MyAccountAdapter(DefaultAccountAdapter):
@@ -20,3 +21,13 @@ class MyAccountAdapter(DefaultAccountAdapter):
             # Handle exception here? Optional for now...
             pass
         return result
+
+# Google login users will not default to the role of 'GUEST'
+class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
+    def save_user(self, request, sociallogin, form=None):
+        user = super().save_user(request, sociallogin, form)
+
+        user.role = "CLIENT"
+        user.save()
+
+        return user


### PR DESCRIPTION
Created the UI for the client page under admin and loaded all users with the role of 'CLIENT'. Admin will be able to use a search bar to search for clients by name, email, or phone number. 

Also made an edit to the Google Sign in feature to ensure new users have the role of 'CLIENT' instead of the default 'GUEST'

<img width="2519" height="1379" alt="image" src="https://github.com/user-attachments/assets/79a241a1-e33f-4908-936c-2f6219352b67" />
