### PR TITLE
LLW-252/253/254/255 + signup error UX fixes

### DIFF
--- a/users/templates/users/signup.html
+++ b/users/templates/users/signup.html
@@ -20,21 +20,21 @@
         <label for="first-name" class="form-label mb-0" style="color:#BDBDBD">
           First Name<span style="color:red;">*</span>
         </label>
-        <input type="text" class="form-control" name="first-name" id="first-name" style="border-radius:1.5rem;" required>
+        <input type="text" class="form-control" name="first-name" id="first-name" style="border-radius:1.5rem;" value="{{ form_data.first_name|default:'' }}" required>
       </div>
 
       <div class="mb-3">
         <label for="last-name" class="form-label mb-0" style="color:#BDBDBD">
           Last Name<span style="color:red;">*</span>
         </label>
-        <input type="text" class="form-control" name="last-name" id="last-name" style="border-radius:1.5rem;" required>
+        <input type="text" class="form-control" name="last-name" id="last-name" style="border-radius:1.5rem;" value="{{ form_data.last_name|default:'' }}" required>
       </div>
 
       <div class="mb-3">
         <label for="email" class="form-label mb-0" style="color:#BDBDBD">
           Email<span style="color:red;">*</span>
         </label>
-        <input type="email" class="form-control" name="email" id="email" style="border-radius:1.5rem;" required>
+        <input type="email" class="form-control" name="email" id="email" style="border-radius:1.5rem;" value="{{ form_data.email|default:'' }}" required>
       </div>
 
       <div class="mb-3">
@@ -42,7 +42,7 @@
           Phone Number<span style="color:red;">*</span>
         </label>
         <input type="tel" class="form-control" name="phone-number" id="phone-number"
-               style="border-radius:1.5rem;" required pattern="[0-9]{10}" title="Must have 10 numbers">
+               style="border-radius:1.5rem;" value="{{ form_data.phone_number|default:'' }}" required pattern="[0-9]{10}" title="Must have 10 numbers">
       </div>
 
       <div class="mb-3">

--- a/users/tests.py
+++ b/users/tests.py
@@ -321,6 +321,35 @@ class SignupTests(TestCase):
         self.assertEqual(User.objects.filter(email="notanemail").count(), 0)
         print("Assertion 3 PASS: no user was created with invalid email")
 
+    def test_signup_password_mismatch_preserves_non_password_fields(self):
+        """
+        On password mismatch, non-password fields should be preserved while
+        password fields remain blank.
+        """
+        post_data = {
+            "first-name": "Jane",
+            "last-name": "Smith",
+            "email": "jane@example.com",
+            "password1": "Password1!",
+            "password2": "DifferentPassword1!",
+            "phone-number": "1234567890",
+        }
+
+        response = self.client.post(self.signup_url, post_data, follow=True)
+        messages_list = list(get_messages(response.wsgi_request))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Passwords do not match.", [str(m) for m in messages_list])
+
+        form_data = response.context.get("form_data", {})
+        self.assertEqual(form_data.get("first_name"), "Jane")
+        self.assertEqual(form_data.get("last_name"), "Smith")
+        self.assertEqual(form_data.get("email"), "jane@example.com")
+        self.assertEqual(form_data.get("phone_number"), "1234567890")
+
+        content = response.content.decode()
+        self.assertNotIn('name="password1" value="Password1!"', content)
+        self.assertNotIn('name="password2" value="DifferentPassword1!"', content)
+
     def test_signup_success_with_valid_data(self):
         """
         Test that signup succeeds with valid email and password

--- a/users/views.py
+++ b/users/views.py
@@ -117,6 +117,12 @@ def signup(r):
 
         password1 = r.POST.get('password1') or ""
         password2 = r.POST.get('password2') or ""
+        form_data = {
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "phone_number": phone_number,
+        }
 
         if (first_name == "" or 
             last_name == "" or 
@@ -125,16 +131,16 @@ def signup(r):
             password1 == "" or 
             password2 == ""):
             messages.error(r, "All fields must be filled in")
-            return render(r, "users/signup.html")
+            return render(r, "users/signup.html", {"form_data": form_data})
 
         # Basic checks
         if password1 != password2:
             messages.error(r, "Passwords do not match.")
-            return render(r, 'users/signup.html')
+            return render(r, 'users/signup.html', {"form_data": form_data})
 
         if password1 != password1.strip():
             messages.error(r, "Password cannot start or end with spaces.")
-            return render(r, 'users/signup.html')
+            return render(r, 'users/signup.html', {"form_data": form_data})
         
         # Checks if email is valid.
         # e.g. (checks for an @, ensures there is a domain like .com, and makes sure both parts are non-empty).
@@ -142,11 +148,11 @@ def signup(r):
             validate_email(email)
         except ValidationError:
             messages.error(r, "Please enter a valid email address.")
-            return render(r, 'users/signup.html')
+            return render(r, 'users/signup.html', {"form_data": form_data})
 
         if User.objects.filter(email__iexact=email).exists():
             messages.error(r, "An account with that email already exists.")
-            return render(r, 'users/signup.html')
+            return render(r, 'users/signup.html', {"form_data": form_data})
 
         # Create the user with a **real** password
         user = User.objects.create_user(


### PR DESCRIPTION
## Summary
- preserves non-password signup fields (`first name`, `last name`, `email`, `phone`) when signup validation fails (e.g., password mismatch)
- keeps password fields blank after errors for safer UX
- keeps explicit signup email errors for invalid format and duplicate emails
- adds regression coverage for password-mismatch field persistence

## Test plan
- [x] `(.venv) python manage.py test users.tests.SignupTests`
- [x] Manual: submit signup with mismatched passwords and verify non-password fields stay populated
- [x] Manual: submit signup with invalid email and verify explicit email error message


Development used Cursor-assisted keystrokes for portions of coding and documentation.
Ownership, review, and final approval remain with ARGiovannini.