### PR TITLE
(IGNORE THIS FOR RN) LLW-285, LLW-286 Appointments Model Logic Tests, Calendly Webhook Tests

### DIFF
--- a/appointments/tests.py
+++ b/appointments/tests.py
@@ -1,3 +1,4 @@
+import json
 import string
 
 from django.test import TestCase, Client
@@ -340,3 +341,291 @@ class AppointmentModelTest(TestCase):
         self.assertEqual(notif.status, Notification.Status.FAILED)
         self.assertEqual(notif.error_message, 'SMTP timeout')
 
+
+class CalendlyWebhookTest(TestCase):
+    """
+    Tests for the Calendly webhook endpoint at POST /webhooks/calendly/.
+
+    When Calendly fires an event (e.g. a client books or cancels), it sends
+    a POST request to this URL with a JSON payload. These tests verify that
+    our view handles every case correctly without ever needing a live Calendly
+    account — we just POST fake-but-realistic JSON directly.
+
+    ── How the test data flows ────────────────────────────────────────────
+    Calendly payload
+        └─ payload.scheduled_event.uri  ──► Appointments.calendly_event_uri
+        └─ payload.uri                  ──► Invitee.calendly_invitee_uri
+        └─ payload.email                ──► matched to a User in our DB
+
+    ── Signature tests ────────────────────────────────────────────────────
+    The last two tests (test_missing_signature_* / test_invalid_signature_*)
+    document REQUIRED but NOT YET IMPLEMENTED behaviour. They will fail
+    until the view validates the Calendly-Webhook-Signature header.
+    """
+
+    WEBHOOK_URL = reverse('calendly_webhook')
+
+    # ── Stable test URIs ──────────────────────────────────────────────────
+    # These mirror the format Calendly uses in real payloads.
+    # The same URI is the idempotency key — sending it twice must not
+    # produce two DB rows.
+    EVENT_URI    = 'https://api.calendly.com/scheduled_events/EVT-001'
+    INVITEE_URI  = 'https://api.calendly.com/scheduled_events/EVT-001/invitees/INV-001'
+    INVITEE_URI2 = 'https://api.calendly.com/scheduled_events/EVT-001/invitees/INV-002'
+
+    def setUp(self):
+        # The view looks up the host by matching event_memberships[0].user_email.
+        # If no match is found it falls back to the first superuser.
+        # We create a superuser here so that fallback always resolves.
+        self.host = User.objects.create_superuser(
+            email='host@example.com',
+            password='hostpass123',
+            first_name='Host',
+            last_name='Admin',
+        )
+        self.host.is_active = True
+        self.host.save()
+
+        # A registered client whose email matches the invitee email in the
+        # payload. The view uses this to associate the appointment with an
+        # existing user account rather than the host.
+        self.client_user = User.objects.create_user(
+            email='client@example.com',
+            password='clientpass123',
+            first_name='Client',
+            last_name='User',
+            role=User.Role.CLIENT,
+        )
+        self.client_user.is_active = True
+        self.client_user.save()
+
+        # Django test client — used to send HTTP requests to the view
+        self.http = Client()
+
+    # ── Payload helpers ───────────────────────────────────────────────────
+    # Building payloads here keeps the tests themselves short and readable.
+    # Each helper returns a dict that matches the real Calendly JSON shape.
+
+    def _created_payload(
+        self,
+        event_uri=None,
+        invitee_uri=None,
+        invitee_email='client@example.com',
+    ):
+        """
+        Builds a realistic 'invitee.created' payload.
+        Calendly sends this when a client successfully books a slot.
+
+        event_memberships tells the view who the host (attorney) is.
+        The view matches user_email against our User table; if found it
+        uses that user, otherwise it falls back to the first superuser.
+        """
+        event_uri   = event_uri   or self.EVENT_URI
+        invitee_uri = invitee_uri or self.INVITEE_URI
+        return {
+            'event': 'invitee.created',
+            'payload': {
+                'uri': invitee_uri,           # unique ID for this invitee record
+                'email': invitee_email,        # client's email — matched to a User
+                'name': 'Client User',
+                'status': 'active',
+                'scheduled_event': {
+                    'uri': event_uri,          # unique ID for the booked slot
+                    'name': 'Consultation',
+                    'status': 'active',
+                    'start_time': '2026-04-01T10:00:00Z',
+                    'end_time':   '2026-04-01T10:30:00Z',
+                    # event_memberships[0].user_email → host user lookup
+                    'event_memberships': [{'user_email': 'host@example.com'}],
+                },
+                'questions_and_answers': [],   # optional pre-booking questions
+            },
+        }
+
+    def _canceled_payload(self, invitee_uri=None):
+        """
+        Builds a realistic 'invitee.canceled' payload.
+        Calendly sends this when a client cancels their booking.
+
+        The view finds the Invitee row by URI, then marks both the
+        Invitee and its parent Appointment as cancelled.
+        """
+        return {
+            'event': 'invitee.canceled',
+            'payload': {'uri': invitee_uri or self.INVITEE_URI},
+        }
+
+    def _post(self, payload, headers=None):
+        """Serialize payload to JSON and POST it to the webhook endpoint."""
+        return self.http.post(
+            self.WEBHOOK_URL,
+            data=json.dumps(payload),
+            content_type='application/json',
+            **(headers or {}),
+        )
+
+    # ── Section 1: HTTP method guard ──────────────────────────────────────
+    # The endpoint must only respond to POST. Any other verb is rejected
+    # immediately with 400 before any DB work happens.
+
+    def test_get_request_returns_400(self):
+        # Calendly always POSTs — a GET most likely means someone mis-typed
+        # the URL in a browser, or a misconfigured ping. Reject it.
+        response = self.http.get(self.WEBHOOK_URL)
+        self.assertEqual(response.status_code, 400)
+
+    def test_put_request_returns_400(self):
+        response = self.http.put(self.WEBHOOK_URL)
+        self.assertEqual(response.status_code, 400)
+
+    def test_post_request_is_accepted(self):
+        # A well-formed POST (even with an unknown event type) gets through
+        # the method guard and returns 200.
+        response = self._post({'event': 'unknown.event', 'payload': {}})
+        self.assertEqual(response.status_code, 200)
+
+    # ── Section 2: invitee.created ────────────────────────────────────────
+    # When a client books a slot, Calendly fires 'invitee.created'.
+    # Our view must create one Appointment row and one Invitee row, linked
+    # together, and return 200.
+
+    def test_invitee_created_creates_appointment(self):
+        # After posting the event we expect exactly one Appointment in the DB
+        # whose calendly_event_uri matches the URI in the payload.
+        self._post(self._created_payload())
+        self.assertEqual(Appointments.objects.filter(calendly_event_uri=self.EVENT_URI).count(), 1)
+
+    def test_invitee_created_appointment_has_confirmed_status(self):
+        # Calendly bookings start life as CONFIRMED (not PENDING) because
+        # Calendly handles the scheduling — no manual approval needed.
+        self._post(self._created_payload())
+        appt = Appointments.objects.get(calendly_event_uri=self.EVENT_URI)
+        self.assertEqual(appt.status, Appointments.Status.CONFIRMED)
+
+    def test_invitee_created_creates_invitee(self):
+        # A separate Invitee row is created to store the client's details
+        # (name, email, reschedule URL, etc.) independently of the Appointment.
+        self._post(self._created_payload())
+        self.assertEqual(Invitee.objects.filter(calendly_invitee_uri=self.INVITEE_URI).count(), 1)
+
+    def test_invitee_created_invitee_linked_to_appointment(self):
+        # The Invitee must point back to its parent Appointment via FK,
+        # so we can look up "who is attending this appointment?".
+        self._post(self._created_payload())
+        appt    = Appointments.objects.get(calendly_event_uri=self.EVENT_URI)
+        invitee = Invitee.objects.get(calendly_invitee_uri=self.INVITEE_URI)
+        self.assertEqual(invitee.appointment, appt)
+
+    def test_invitee_created_associates_registered_client(self):
+        # If the invitee's email matches a User in our DB, the Appointment
+        # should be owned by that client — not the host/attorney.
+        self._post(self._created_payload(invitee_email='client@example.com'))
+        appt = Appointments.objects.get(calendly_event_uri=self.EVENT_URI)
+        self.assertEqual(appt.user_id, self.client_user)
+
+    def test_invitee_created_returns_200(self):
+        response = self._post(self._created_payload())
+        self.assertEqual(response.status_code, 200)
+
+    # ── Section 3: invitee.canceled ───────────────────────────────────────
+    # When a client cancels, Calendly fires 'invitee.canceled' with the
+    # same invitee URI that was in the original 'invitee.created' event.
+    # Our view uses that URI to find the right row and mark it cancelled.
+
+    def test_invitee_canceled_sets_appointment_status_to_cancelled(self):
+        # Step 1 — simulate the original booking arriving
+        self._post(self._created_payload())
+        # Step 2 — simulate the cancellation arriving
+        self._post(self._canceled_payload())
+
+        appt = Appointments.objects.get(calendly_event_uri=self.EVENT_URI)
+        self.assertEqual(appt.status, Appointments.Status.CANCELLED)
+
+    def test_invitee_canceled_sets_invitee_canceled_flag(self):
+        # The Invitee row itself also gets a `canceled = True` flag so we
+        # can distinguish "was cancelled" from "was rescheduled".
+        self._post(self._created_payload())
+        self._post(self._canceled_payload())
+
+        invitee = Invitee.objects.get(calendly_invitee_uri=self.INVITEE_URI)
+        self.assertTrue(invitee.canceled)
+
+    def test_invitee_canceled_for_unknown_invitee_returns_200(self):
+        # If Calendly sends a cancellation for a URI we don't recognise
+        # (e.g. a booking that predates our system) we log and return 200
+        # rather than crashing — defensive handling.
+        response = self._post(self._canceled_payload(invitee_uri='https://calendly.com/unknown'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_invitee_canceled_returns_200(self):
+        self._post(self._created_payload())
+        response = self._post(self._canceled_payload())
+        self.assertEqual(response.status_code, 200)
+
+    # ── Section 4: Idempotency ────────────────────────────────────────────
+    # Webhooks are "at-least-once" — Calendly may retry if it doesn't receive
+    # a timely 200. Sending the same event twice must produce the same result
+    # as sending it once (no duplicate rows, no errors).
+    #
+    # The view achieves this with get_or_create keyed on the Calendly URI,
+    # which is globally unique per booking / per invitee.
+
+    def test_duplicate_invitee_created_does_not_duplicate_appointment(self):
+        payload = self._created_payload()
+        self._post(payload)  # first delivery
+        self._post(payload)  # Calendly retry — must be a no-op
+        self.assertEqual(Appointments.objects.filter(calendly_event_uri=self.EVENT_URI).count(), 1)
+
+    def test_duplicate_invitee_created_does_not_duplicate_invitee(self):
+        payload = self._created_payload()
+        self._post(payload)
+        self._post(payload)
+        self.assertEqual(Invitee.objects.filter(calendly_invitee_uri=self.INVITEE_URI).count(), 1)
+
+    def test_duplicate_invitee_canceled_leaves_appointment_cancelled(self):
+        # Cancelling an already-cancelled appointment must stay CANCELLED,
+        # not raise an error or flip back to another status.
+        self._post(self._created_payload())
+        self._post(self._canceled_payload())  # first cancel
+        self._post(self._canceled_payload())  # duplicate cancel — must be safe
+
+        appt = Appointments.objects.get(calendly_event_uri=self.EVENT_URI)
+        self.assertEqual(appt.status, Appointments.Status.CANCELLED)
+
+    # ── Section 5: Unrecognised event type ────────────────────────────────
+    # Calendly has many event types (routing_form.submission, etc.) that we
+    # don't handle. We return 200 so Calendly stops retrying, but we do
+    # nothing to the database.
+
+    def test_unknown_event_returns_200(self):
+        response = self._post({'event': 'routing_form.submission', 'payload': {}})
+        self.assertEqual(response.status_code, 200)
+
+    def test_unknown_event_does_not_create_appointment(self):
+        self._post({'event': 'routing_form.submission', 'payload': {}})
+        self.assertEqual(Appointments.objects.count(), 0)
+
+    # ── Section 6: Signature validation (NOT YET IMPLEMENTED) ────────────
+    # Calendly signs every webhook with an HMAC-SHA256 signature sent in
+    # the Calendly-Webhook-Signature header. Verifying this prevents anyone
+    # on the internet from spoofing fake bookings or cancellations.
+    #
+    # !! These two tests will FAIL on the current code !!
+    # They are written now so the requirement is visible in the test suite.
+    # Once the view reads CALENDLY_WEBHOOK_SECRET from settings and validates
+    # the header, these tests will begin passing automatically.
+
+    def test_missing_signature_header_returns_403(self):
+        # A request with no signature header should be rejected — it could
+        # be anyone, not Calendly.
+        response = self._post(self._created_payload())
+        self.assertIn(response.status_code, [400, 403])
+
+    def test_invalid_signature_returns_403(self):
+        # A request where the signature doesn't match our secret should
+        # also be rejected, even if the JSON body looks valid.
+        response = self._post(
+            self._created_payload(),
+            headers={'HTTP_CALENDLY_WEBHOOK_SIGNATURE': 'invalid-signature'},
+        )
+        self.assertIn(response.status_code, [400, 403])


### PR DESCRIPTION
- AppointmentModelTest: confirmation number auto-generation (8-char, uppercase alphanumeric, unique)
- AppointmentModelTest: valid status transitions (PENDING→CONFIRMED/CANCELLED, CONFIRMED→COMPLETED/NO_SHOW/CANCELLED)
- AppointmentModelTest: invalid status transitions rejected (COMPLETED→PENDING, CANCELLED→PENDING, etc.)
- AppointmentModelTest: Invitee creation linked to parent appointment
- AppointmentModelTest: cancellation stores cancelled_at timestamp and cancellation_reason
- AppointmentModelTest: Notification model stores channel, type, and status fields correctly
