### PR TITLE
LLW-326: Distinct admin login and link back to user login

### DIFF
--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,90 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/login.css" %}">
+{{ form.media }}
+<style>
+  .django-admin-login-banner {
+    background: rgba(17, 90, 92, 0.12);
+    border: 2px solid #115A5C;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 20px;
+    max-width: 28rem;
+  }
+  .django-admin-login-banner strong {
+    color: #115A5C;
+  }
+</style>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} login{% endblock %}
+
+{% block usertools %}{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block nav-sidebar %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block nav-breadcrumbs %}{% endblock %}
+
+{% block content %}
+<div class="django-admin-login-banner">
+  <strong>{% translate "Django administration login" %}</strong>
+  <p style="margin: 8px 0 0 0; font-size: 13px;">
+    {% translate "For client appointments and account access, use the site login." %}
+    <a href="{% url 'login' %}">{% translate "Client login" %}</a>
+  </p>
+</div>
+
+{% if form.errors and not form.non_field_errors %}
+<p class="errornote">
+{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+</p>
+{% endif %}
+
+{% if form.non_field_errors %}
+{% for error in form.non_field_errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+<div id="content-main">
+
+{% if user.is_authenticated %}
+<p class="errornote">
+{% blocktranslate trimmed %}
+    You are authenticated as {{ username }}, but are not authorized to
+    access this page. Would you like to login to a different account?
+{% endblocktranslate %}
+</p>
+{% endif %}
+
+<form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
+  <div class="form-row">
+    {{ form.username.errors }}
+    {{ form.username.label_tag }} {{ form.username }}
+  </div>
+  <div class="form-row">
+    {{ form.password.errors }}
+    {{ form.password.label_tag }} {{ form.password }}
+    <input type="hidden" name="next" value="{{ next }}">
+  </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  {% if password_reset_url %}
+  <div class="password-reset-link">
+    <a href="{{ password_reset_url }}">{% translate 'Forgotten your login credentials?' %}</a>
+  </div>
+  {% endif %}
+  <div class="submit-row">
+    <input type="submit" value="{% translate 'Log in' %}">
+  </div>
+</form>
+
+</div>
+{% endblock %}

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -2,8 +2,14 @@
 {% load socialaccount %}
 {% block content %}
 <div class="d-flex justify-content-center mt-5">
+    {% if role == 'admin' %}
+    <div class="card shadow px-5 py-4 border-2" style="width: 35rem; background-color: rgba(17, 90, 92, 0.12); border-radius: 1rem; border-color: #115A5C !important;">
+        <h3 class="mb-2" style="color: #115A5C;">Staff login</h3>
+        <p class="small mb-4" style="color: #333333;">Authorized staff only. Use your work email and password.</p>
+    {% else %}
     <div class="card shadow px-5 py-4" style="width: 35rem; background-color: rgb(120, 156, 148, 0.17); border-radius: 1rem; border: none;">
         <h3 class="mb-4" style="color: #333333;">Login</h3>
+    {% endif %}
 
         <form method="post" action="{% url 'login' %}">
             {% csrf_token %}
@@ -39,6 +45,12 @@
             {% endif %}
         </form>
 
+        {% if role == 'admin' %}
+        <div class="text-center small mb-2">
+            <span style="color: #BDBDBD !important">Not staff?</span>
+            <a href="{% url 'login' %}" class="text-decoration-none" style="color: #115A5C !important">Client login</a>
+        </div>
+        {% else %}
         <div class="text-center small">
             <span style="color: #BDBDBD !important">Are you an Admin?</span>
             <a href="{% url 'login' %}?role=admin" class="text-decoration-none" style="color: #115A5C !important">Login</a>
@@ -47,6 +59,7 @@
             <span style="color: #BDBDBD !important">Don't have an account?</span>
             <a href="{% url 'signuppage' %}" class="text-decoration-none" style="color: #115A5C !important">Sign up</a>
         </div>
+        {% endif %}
 
     </div>
 </div>

--- a/users/tests.py
+++ b/users/tests.py
@@ -225,6 +225,20 @@ class LoginTests(TestCase):
         self.assertEqual(response.status_code, 401)
         print("Assertion 4 PASS: response.status_code == 401")
 
+    def test_staff_login_page_shows_distinct_copy_and_client_login_link(self):
+        response = self.client.get(self.login_url, {"role": "admin"})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Staff login")
+        self.assertContains(response, "Authorized staff only")
+        self.assertContains(response, "Client login")
+        self.assertContains(response, f'href="{self.login_url}"')
+
+    def test_client_login_page_links_to_staff_login(self):
+        response = self.client.get(self.login_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Are you an Admin?")
+        self.assertContains(response, f'href="{self.login_url}?role=admin"')
+
 
 class SignupTests(TestCase):
     """Test user signup functionality and error messages"""


### PR DESCRIPTION
## Summary
- Make staff login visually distinct (role=admin) and add link back to client login
- Add tests covering staff/client login variants
- (Optional) Override Django admin login template with link back to site login

## Test plan
- [ ] `./.venv/bin/python manage.py test users.tests`

Development used Cursor-assisted keystrokes for portions of coding and documentation.
Ownership, review, and final approval remain with ARGiovannini.