### PR TITLE
LLW-356 Robot.txt & Sitemap.xml for SEO

### DIFF
--- a/Lydias_Law_Site/settings.py
+++ b/Lydias_Law_Site/settings.py
@@ -86,7 +86,8 @@ INSTALLED_APPS = [
     "appointments",
     "sitecontent",
     "finances",
-    "django_ckeditor_5"
+    "django_ckeditor_5",
+    "django.contrib.sitemaps"
 ]
 
 

--- a/Lydias_Law_Site/urls.py
+++ b/Lydias_Law_Site/urls.py
@@ -18,6 +18,14 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.generic import RedirectView
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.sitemaps.views import sitemap
+from core.sitemaps import StaticViewSitemap
+
+sitemaps = {
+    'static': StaticViewSitemap(),
+}
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -27,6 +35,15 @@ urlpatterns = [
     path("appointments/", include("appointments.urls")),
     path("ckeditor5/", include('django_ckeditor_5.urls')),
     path("", include("finances.urls")),
+    
+    # For SEO (Google crawl)
+    # From core/sitemap.py and core/static/core/robot.txt file
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
+    path("robots.txt", RedirectView.as_view(
+        url=staticfiles_storage.url("core/robots.txt"),
+        permanent=True
+    )),
+
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 

--- a/core/sitemaps.py
+++ b/core/sitemaps.py
@@ -1,0 +1,18 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+class StaticViewSitemap(Sitemap):
+    def items(self):
+        return [
+            'home', 
+            'about', 
+            'contact', 
+            'practice_areas',
+            'services',
+            'payment',
+            'schedule',
+            'privacy',
+        ]  #  URL names
+
+    def location(self, item):
+        return reverse(item)

--- a/core/static/core/robots.txt
+++ b/core/static/core/robots.txt
@@ -1,0 +1,15 @@
+User-agent: *
+Disallow: /administrator/
+Disallow: /client/
+Disallow: /admin/
+Disallow: /appointments/
+Disallow: /accounts/
+Disallow: /login/
+Disallow: /logout/
+Disallow: /users/
+Disallow: /payment/failure/
+Disallow: /payment/success/
+
+Allow: /
+
+Sitemap: https://adoptionsofsac.com/sitemap.xml

--- a/core/templates/partials/payment_failure_content.html
+++ b/core/templates/partials/payment_failure_content.html
@@ -1,6 +1,9 @@
 {% block content %}
 {% load static %}
 
+<!-- Blocks Google/SEO crawls from this page if linked by others -->
+<meta name="robots" content="noindex, nofollow">
+
 <style>
 .serif-text {
     font-family: serif;

--- a/core/templates/partials/payment_success_content.html
+++ b/core/templates/partials/payment_success_content.html
@@ -2,6 +2,9 @@
 {% block content %}   
 {% load static %}
 
+<!-- Blocks Google/SEO crawls from this page if linked by others -->
+<meta name="robots" content="noindex, nofollow">
+
 <style>
 .serif-text {
     font-family: serif;


### PR DESCRIPTION
Added a robot.txt and sitemap.py file which will help Google crawl the site (allowing/disallowing pages).
_Also added a meta so that the payment/success and payment/failure page don't get crawled if they're linked anywhere._

**_To test,_** go to these sites locally (after you **'git switch LLW-356-Robot.txt-Creation-Google-Search'** in terminal) :

- http://[127.0.0.1:8000/robots.txt](http://127.0.0.1:8000/static/core/robots.txt)
- http://[127.0.0.1:8000/sitemap.xml](http://127.0.0.1:8000/sitemap.xml)

Should see something like this:

Robot.txt:
<img width="586" height="366" alt="image" src="https://github.com/user-attachments/assets/ef0c1215-9ac3-4b63-a62b-8149ea60b8d1" />

Sitemap.xml:
<img width="1169" height="610" alt="image" src="https://github.com/user-attachments/assets/900e03df-3aa4-4648-b1d8-84b7848faf21" />
