### PR TITLE
LLW-138, added seo alt text and meta descriptions for all images

### DIFF
--- a/core/templates/about.html
+++ b/core/templates/about.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% block title %}About{% endblock %}
+{% block title %}About Lydia A. Suprun – Attorney at Law{% endblock %}
+{% block meta_description %}Learn about Lydia A. Suprun, an experienced adoption and guardianship attorney dedicated to helping families navigate legal processes with care and expertise.{% endblock %}
 
 {% block content %}
 {% include 'partials/about_content.html' %}

--- a/core/templates/admin/appointment_confirmation.html
+++ b/core/templates/admin/appointment_confirmation.html
@@ -14,7 +14,7 @@
 
                         <!-- Container for Logo -->
                         <div class=" mb-3 mb-md-0 me-md-4">
-                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                            <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" width="200px">
                         </div>
 
                         <!-- Container for Text-->

--- a/core/templates/admin/invoice_confirmation.html
+++ b/core/templates/admin/invoice_confirmation.html
@@ -14,7 +14,7 @@
 
                         <!-- Container for Logo -->
                         <div class=" mb-3 mb-md-0 me-md-4">
-                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                            <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" width="200px">
                         </div>
 
                         <!-- Container for Text-->

--- a/core/templates/appointment_confirmation.html
+++ b/core/templates/appointment_confirmation.html
@@ -14,7 +14,7 @@
 
                         <!-- Container for Logo -->
                         <div class=" mb-3 mb-md-0 me-md-4">
-                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                            <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" width="200px">
                         </div>
 
                         <!-- Container for Text-->

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}Lydia A. Suprun – Adoption & Guardianship{% endblock %}</title>
-    <meta name="description" content="{% block meta_description %}Legal services. Schedule online and pay securely.{% endblock %}">
+    <meta name="description" content="{% block meta_description %}Law Office of Lydia A. Suprun – Compassionate legal representation in adoption, guardianship, and family law. Schedule a free consultation online.{% endblock %}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{% static 'css/footer.css' %}">
     <link rel="stylesheet" href="{% static 'css/style.css' %}">

--- a/core/templates/client/appointment_confirmation.html
+++ b/core/templates/client/appointment_confirmation.html
@@ -13,7 +13,7 @@
 
                         <!-- Container for Logo -->
                         <div class=" mb-3 mb-md-0 me-md-4">
-                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                            <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" width="200px">
                         </div>
 
                         <!-- Container for Text-->

--- a/core/templates/contact.html
+++ b/core/templates/contact.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% block title %}Contact{% endblock %}
+{% block title %}Contact – Law Office of Lydia A. Suprun{% endblock %}
+{% block meta_description %}Contact the Law Office of Lydia A. Suprun to schedule a consultation. Reach us by phone, email, or use our online booking form for adoption and family law inquiries.{% endblock %}
 
 {% block content %}
 {% include 'partials/contact_content.html' %}

--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -1,11 +1,13 @@
 {% extends 'base.html' %}
 
+{% block meta_description %}Law Office of Lydia A. Suprun – Dedicated attorney specializing in adoption, guardianship, and family law. Serving clients with compassion. Schedule your free consultation today.{% endblock %}
+
 {% block content %}
 {% load static %}
 
 <!-- Hero Image with Text -->
 <div class="no-padding">
-<section class="hero" style="background-image: url('{% static "images/home_header.jpg" %}');">
+<section class="hero" style="background-image: url('{% static "images/home_header.jpg" %}');" title="Law Office of Lydia A. Suprun - Professional Legal Services" aria-label="Hero banner with office building showcasing legal services">
     <div class="hero-text">
           <h1>{{ content.frontPageHeader|safe }}</h1>
     </div>
@@ -24,7 +26,7 @@
  <section>
   <div class="button-grid">
       {% for area in pa_buttons %}
-      <a href="practice-areas" class="image-btn" style="background-image: url('{% static area.image_static_path %}');" alt="{{ area.title }}">
+      <a href="practice-areas" class="image-btn" style="background-image: url('{% static area.image_static_path %}');" title="View {{ area.title }} legal services" aria-label="{{ area.title }} - Click to view details about our {{ area.title|lower }} practice area">
           <span class="btn-text">{{ area.title }}</span>
       </a>
       {% endfor %}

--- a/core/templates/partials/admin_navbar.html
+++ b/core/templates/partials/admin_navbar.html
@@ -4,7 +4,7 @@
 <nav class="navbar navbar-expand-lg" style="background-color: #5a7a73;">
   <div class="container-fluid px-4">
     <a class="navbar-brand text-white d-flex align-items-center" href="{% url 'home' %}">
-      <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun" style="width: 100px; height: 100px;" class="me-3">
+      <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" style="width: 100px; height: 100px;" class="me-3">
     </a>
 
     <button class="navbar-toggler text-white border-white" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav">

--- a/core/templates/partials/client_navbar.html
+++ b/core/templates/partials/client_navbar.html
@@ -6,7 +6,7 @@
     
     <!-- Logo -->
     <a class="navbar-brand text-white d-flex align-items-center" href="{% url 'home' %}">
-      <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun" style="width: 100px; height: 100px;" class="me-3">
+      <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" style="width: 100px; height: 100px;" class="me-3">
     </a>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav"><span class="navbar-toggler-icon"></span></button>

--- a/core/templates/partials/contact_content.html
+++ b/core/templates/partials/contact_content.html
@@ -271,17 +271,17 @@
 <!--Three contact cards-->
 <div class="contact-card-container">
     <div class="contact-card">
-        <img src="{% static 'images/location.png'%}" alt="Location icon" style="width: 85px; height: 85px; padding: 1rem">
+        <img src="{% static 'images/location.png'%}" alt="Office location icon for {{location.officeLocation}}" title="Office Location" style="width: 85px; height: 85px; padding: 1rem">
         <h5>Office Location</h5>
         <p>{{location.officeLocation}}</p>
     </div>
     <div class="contact-card">
-        <img src="{% static 'images/telephone.png'%}" alt="Telephone icon" style="width: 85px; height: 85px; padding: 1rem">
+        <img src="{% static 'images/telephone.png'%}" alt="Telephone icon to call {{location.phoneNumber}}" title="Phone Number" style="width: 85px; height: 85px; padding: 1rem">
         <h5>Phone Number</h5>
         <p>{{location.phoneNumber}}</p>
     </div>
     <div class="contact-card">
-        <img src="{% static 'images/email.png'%}" alt="Email icon" style="width: 85px; height: 85px; padding: 1rem">
+        <img src="{% static 'images/email.png'%}" alt="Email icon to contact at {{location.emailAddress}}" title="Email Address" style="width: 85px; height: 85px; padding: 1rem">
         <h5>Email Address</h5>
         <p>{{location.emailAddress}}</p>
     </div>

--- a/core/templates/partials/navbar.html
+++ b/core/templates/partials/navbar.html
@@ -6,7 +6,7 @@
     
     <!-- Logo -->
     <a class="navbar-brand text-white d-flex align-items-center" href="{% url 'home' %}">
-      <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun" style="width: 100px; height: 100px;" class="me-3">
+      <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" style="width: 100px; height: 100px;" class="me-3">
     </a>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav"><span class="navbar-toggler-icon"></span></button>

--- a/core/templates/partials/payment_failure_content.html
+++ b/core/templates/partials/payment_failure_content.html
@@ -20,7 +20,7 @@
 
                         <!-- Container for Logo -->
                         <div class=" mb-3 mb-md-0 me-md-4">
-                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                            <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" width="200px">
                         </div>
 
                         <!-- Container for Text-->

--- a/core/templates/partials/payment_success_content.html
+++ b/core/templates/partials/payment_success_content.html
@@ -21,7 +21,7 @@
 
                         <!-- Container for Logo -->
                         <div class=" mb-3 mb-md-0 me-md-4">
-                            <img src="{% static 'images/logo.png' %}" alt="Logo" width="200px" >
+                            <img src="{% static 'images/logo.png' %}" alt="Law Office of Lydia A. Suprun - Attorney Logo" title="Law Office of Lydia A. Suprun" width="200px">
                         </div>
 
                         <!-- Container for Text-->

--- a/core/templates/partials/practice_areas_content.html
+++ b/core/templates/partials/practice_areas_content.html
@@ -115,7 +115,7 @@
   {% for area in practice_areas %}
   <div class="practice-area-card">
     <div class="practice-area-image">
-      <img src="{% static area.image_static_path %}" alt="{{ area.title }}">
+      <img src="{% static area.image_static_path %}" alt="Professional representation for {{ area.title }} services" title="{{ area.title }} - Law Office of Lydia A. Suprun">
       <div class="practice-area-image-title">{{ area.title }}</div>
     </div>
     <div class="practice-area-content">

--- a/core/templates/practice_areas.html
+++ b/core/templates/practice_areas.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Practice Areas{% endblock %}
+{% block title %}Practice Areas – Law Office of Lydia A. Suprun{% endblock %}
+{% block meta_description %}Explore the legal practice areas of Lydia A. Suprun, including adoption, guardianship, stepparent adoption, and more. Expert family law representation tailored to your needs.{% endblock %}
 
 {% block content %}
 {% include 'partials/practice_areas_content.html' %}


### PR DESCRIPTION
Add SEO alt text, title attributes, and meta descriptions for all images

- Replace generic alt="Logo" with descriptive text across all templates
- Add title attributes to logo and contact icon images
- Improve practice area image alt text to describe legal services context
- Add aria-label and title to CSS background images on home page hero and buttons
- Add per-page meta_description blocks to home, about, contact, and practice areas
- Improve page <title> tags on about, contact, and practice areas pages
- Strengthen base.html fallback meta description
